### PR TITLE
fix: add `main` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ansi-to",
-	"main": "ansi-to",
+	"main": "index.js",
 	"version": "1.5.1",
 	"description": "😹  export ANSI to HTML, SVG, PNG, w/ iTerm2 color support",
 	"license": "MIT",


### PR DESCRIPTION
Hi,

Getting the following messages when using an app that depends on yours:

```
(node:79143) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/brett/httpquery/node_modules/.pnpm/ansi-to-svg@1.4.3/node_modules/ansi-to/package.json' of 'ansi-to'. Please either fix that or report it to the module author
```

Thanks!